### PR TITLE
Verbose printing and corrected update

### DIFF
--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -66,7 +66,7 @@ filtered <- function(data, pval=0.01, fval=0.01, verbose=FALSE) {
   bad_quality <- (probe_quality == "Bad") | (probe_quality == "No match")
   
   if(verbose){
-    cat("Removing", sum(remove), "probes that were not present in", 
+    cat("Removing", sum(remove), "probes that were not present in at least", 
         fval*100, "% of the samples.\n")
     cat("Removing", sum(bad_quality), "bad quality probes.\n")
   }
@@ -84,8 +84,8 @@ probe_aggregated <- function(data, verbose=FALSE) {
   
   probes_out = length(Biobase::featureNames(data))
   if(verbose){
-    cat("Removed", probes_in-probes_out,
-      "probes after aggregating across annotated probes.\n")
+    cat("Filtered out", probes_in-probes_out,
+      "probes.\n")
   }
   
   data

--- a/R/preprocessing.R
+++ b/R/preprocessing.R
@@ -49,21 +49,26 @@ normalized <- function(data) {
 }
 
 # standards by gunther
-# fval: present in at least (fval)% of samples
+# fval: present in at least (fval*100)% of samples
 # also filters bad probes
 #' @export
 filtered <- function(data, pval=0.01, fval=0.01) {
   threshold <- round(fval*ncol(data))
 
   # counts number of samples with probe detectable at pval level
-  present <- detectionCall(data, Th=pval, type="probe")
+  present <- lumi::detectionCall(data, Th=pval, type="probe")
   remove <- present < threshold
 
+  cat("Removing", sum(remove), "probes that were not present in", 
+      fval*100, "% of the samples.\n")
+  
   probeq <- illuminaHumanv4.db::illuminaHumanv4PROBEQUALITY
   probes <- lumi::nuID2IlluminaID(rownames(data), lib.mapping=NULL,
                                   species ="Human", idType='Probe')
   probe_quality <- unlist(AnnotationDbi::mget(as.character(probes), probeq, ifnotfound=NA))
   bad_quality <- (probe_quality == "Bad") | (probe_quality == "No match")
+  
+  cat("Removing", sum(bad_quality), "bad quality probes.\n")
 
   data <- data[-which(remove | bad_quality), ]
   data

--- a/tests/testthat/test_corrected.R
+++ b/tests/testthat/test_corrected.R
@@ -1,0 +1,30 @@
+testdata <- matrix(c(rnorm(100, mean=10, sd=1),
+                     rnorm(100, mean=10, sd=2),
+                     rnorm(100, mean=10, sd=3), 
+                     rnorm(100, mean=10, sd=4)), 
+                     nrow = 100)
+
+negs <- cbind(testdata, matrix(c(rnorm(100, mean=10, sd=1),
+                 rnorm(100, mean=10, sd=2)),
+                 nrow=100)) 
+
+colnames(testdata) <- c("V1","V2","V3","V4")
+colnames(negs) <- c(colnames(testdata), "V5", "V6")
+
+testdata_with_zeros <- cbind(testdata, rep(0, 100))
+colnames(testdata_with_zeros) <- c("V1","V2","V3","V4","zeros")
+
+testdata_with_negative <- cbind(testdata, rnorm(100,sd=1))
+colnames(testdata_with_negative) <- c("V1","V2","V3","V4","negative")
+
+test_that("corrected() works when all values are positive", {
+  expect_output(corrected(testdata, negs))
+})
+
+test_that("corrected() throws an error when one column is all zeros", {
+  expect_error(corrected(testdata_with_zeros, negs))
+})
+
+test_that("corrected() throws an error when one column has negative values",{
+  expect_error(corrected(testdata_with_negative, negs))
+})


### PR DESCRIPTION
New additions: 
- Functions that remove samples have an added `verbose=FALSE` argument that can be set to`TRUE` to print the removed samples.
- `corrected` now works with both matrices and LumiBatch objects.
- `corrected` will throw an error if there are samples with either negative gene expression values or gene expression values with no variance (ie. they are equal).
- small test to verify that `corrected` throws an error when we have funky gene expression values. 

Cheers&Beers,
Bjørn
